### PR TITLE
Add Semigroup Superclass

### DIFF
--- a/Control/Monad/Levels.hs
+++ b/Control/Monad/Levels.hs
@@ -45,9 +45,10 @@ newtype Levels a = Levels { levels :: [FMList a] }
 runLevels :: Levels a -> [a]
 runLevels = toList . foldr append empty . levels
 
+instance Semigroup (Levels a) where
+  a <> b = Levels (empty : merge (levels a) (levels b))
 instance Monoid (Levels a) where
   mempty        = Levels []
-  a `mappend` b = Levels (empty : merge (levels a) (levels b))
 
 -- like 'zipWith append' without cutting the longer list
 merge :: [FMList a] -> [FMList a] -> [FMList a]
@@ -80,7 +81,8 @@ idfsBy n a = toList $ foldr append empty [ unFM a yield ! d | d <- [0,n..] ]
 -- to iterative deepening search.
 newtype DepthBound a = DepthBound { (!) :: Int -> FMList a }
 
+instance Semigroup (DepthBound a) where
+  a <> b = DepthBound (\d -> if d==0 then empty
+                                    else append (a!(d-1)) (b!(d-1)))
 instance Monoid (DepthBound a) where
   mempty        = DepthBound (const empty)
-  a `mappend` b = DepthBound (\d -> if d==0 then empty
-                                    else append (a!(d-1)) (b!(d-1)))


### PR DESCRIPTION
The commit adds the Semigroup Superclass to add compatibility for GHC-8.4 and newer. This breaks compatibility with 8.2 and older. I don't think many people still use those, but I could add CPP ifdefs if necessary.

This is the only level-monad implementation I could find on Hackage thanks for writing this!